### PR TITLE
fix(header): Resolve Dark Mode Toggle Icon Issue

### DIFF
--- a/_sass/_dark-mode.scss
+++ b/_sass/_dark-mode.scss
@@ -96,12 +96,12 @@ html.dark-mode {
         background-color: rgba(lighten($primary-color, 20%), 0.1);
       }
       
-      .sun {
-        display: block;
+      .theme-toggle-icon.sun {
+        display: block !important;
       }
       
-      .moon {
-        display: none;
+      .theme-toggle-icon.moon {
+        display: none !important;
       }
     }
   }

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -171,16 +171,26 @@
       transform: rotate(15deg);
     }
     
+    &.dark-active {
+      .theme-toggle-icon.sun {
+        display: block;
+      }
+      
+      .theme-toggle-icon.moon {
+        display: none;
+      }
+    }
+    
     .theme-toggle-icon {
       width: 20px;
       height: 20px;
     }
     
-    .sun {
+    .theme-toggle-icon.sun {
       display: none;
     }
     
-    .moon {
+    .theme-toggle-icon.moon {
       display: block;
     }
   }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,8 +27,10 @@ function initDarkMode() {
   const darkModeEnabled = html.getAttribute('data-dark-mode-enabled') === 'true';
   
   // Debug - log the current state
-  console.log('Dark mode enabled:', darkModeEnabled);
-  console.log('Dark mode class present:', html.classList.contains('dark-mode'));
+  if (typeof DEBUG !== 'undefined' && DEBUG) {
+    console.log('Dark mode enabled:', darkModeEnabled);
+    console.log('Dark mode class present:', html.classList.contains('dark-mode'));
+  }
   
   // If dark mode is completely disabled, ensure light mode is always applied
   if (!darkModeEnabled) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,10 +26,24 @@ function initDarkMode() {
   const html = document.documentElement;
   const darkModeEnabled = html.getAttribute('data-dark-mode-enabled') === 'true';
   
+  // Debug - log the current state
+  console.log('Dark mode enabled:', darkModeEnabled);
+  console.log('Dark mode class present:', html.classList.contains('dark-mode'));
+  
   // If dark mode is completely disabled, ensure light mode is always applied
   if (!darkModeEnabled) {
     html.classList.remove('dark-mode');
     localStorage.setItem('theme', 'light');
+    showLightModeIcon(themeToggle);
+  } else {
+    // Add dark-active class to the toggle button if currently in dark mode
+    if (html.classList.contains('dark-mode')) {
+      themeToggle.classList.add('dark-active');
+      showDarkModeIcon(themeToggle);
+    } else {
+      themeToggle.classList.remove('dark-active');
+      showLightModeIcon(themeToggle);
+    }
   }
   
   themeToggle.addEventListener('click', function() {
@@ -37,17 +51,37 @@ function initDarkMode() {
     if (!darkModeEnabled) {
       html.classList.remove('dark-mode');
       localStorage.setItem('theme', 'light');
+      showLightModeIcon(themeToggle);
       return;
     }
     
     if (html.classList.contains('dark-mode')) {
       html.classList.remove('dark-mode');
+      themeToggle.classList.remove('dark-active');
       localStorage.setItem('theme', 'light');
+      showLightModeIcon(themeToggle);
     } else {
       html.classList.add('dark-mode');
+      themeToggle.classList.add('dark-active');
       localStorage.setItem('theme', 'dark');
+      showDarkModeIcon(themeToggle);
     }
   });
+  
+  // Helper functions to toggle icons
+  function showDarkModeIcon(toggle) {
+    const sunIcon = toggle.querySelector('.sun');
+    const moonIcon = toggle.querySelector('.moon');
+    if (sunIcon) sunIcon.style.display = 'block';
+    if (moonIcon) moonIcon.style.display = 'none';
+  }
+  
+  function showLightModeIcon(toggle) {
+    const sunIcon = toggle.querySelector('.sun');
+    const moonIcon = toggle.querySelector('.moon');
+    if (sunIcon) sunIcon.style.display = 'none';
+    if (moonIcon) moonIcon.style.display = 'block';
+  }
 }
 
 /**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,12 +26,6 @@ function initDarkMode() {
   const html = document.documentElement;
   const darkModeEnabled = html.getAttribute('data-dark-mode-enabled') === 'true';
   
-  // Debug - log the current state
-  if (typeof DEBUG !== 'undefined' && DEBUG) {
-    console.log('Dark mode enabled:', darkModeEnabled);
-    console.log('Dark mode class present:', html.classList.contains('dark-mode'));
-  }
-  
   // If dark mode is completely disabled, ensure light mode is always applied
   if (!darkModeEnabled) {
     html.classList.remove('dark-mode');


### PR DESCRIPTION
<!--
Thank you for contributing to Arsxy Theme!
-->

## Description
This pull request refines the dark mode functionality by improving the handling of theme toggle icons, adding helper functions for better code clarity, and introducing debug logs for easier troubleshooting. The changes span both CSS and JavaScript files, ensuring a more consistent and maintainable implementation.

### Dark Mode Icon Handling Improvements:
* Updated CSS in `_sass/_dark-mode.scss` to use the `.theme-toggle-icon` class for better specificity and added `!important` to ensure proper display behavior for `.sun` and `.moon` icons.
* Enhanced `_sass/components/_header.scss` by introducing a `.dark-active` class for the toggle button, ensuring the correct icon (`.sun` or `.moon`) is displayed based on the current theme.

### JavaScript Enhancements:
* Modified `assets/js/main.js` to add helper functions `showDarkModeIcon` and `showLightModeIcon` for toggling the visibility of `.sun` and `.moon` icons, improving code readability and reusability.
* Added logic to dynamically toggle the `.dark-active` class on the theme toggle button based on the current theme, ensuring visual consistency.
* Included debug logs in `initDarkMode` to log the state of dark mode and the presence of the `dark-mode` class, aiding in troubleshooting.

## Related Issue

## Type of Change
<!-- Mark the appropriate options with 'x' (e.g. [x]) -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## Checklist
<!-- Mark the appropriate options with 'x' (e.g. [x]) -->

- [x] I have tested my changes
- [ ] I have updated the documentation accordingly
- [x] My changes don't break existing functionality

## Screenshots
<img width="1407" alt="Screenshot 2025-05-16 at 09 33 03" src="https://github.com/user-attachments/assets/1a92fc9e-80be-4454-bdeb-1e1b47abfafb" />
<img width="1415" alt="Screenshot 2025-05-16 at 09 33 08" src="https://github.com/user-attachments/assets/cb4b930f-83a7-48bc-9e43-6e3693ab3a7d" />

