### PR TITLE
fix(search): Create Better Styling in Light Mode

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -29,11 +29,15 @@
   --secondary-color: #{$secondary-color};
   // --accent-color: #{$accent-color};
   --text-color: #{$text-color};
-  // --background-color: #{$background-color};
-  // --background-color-alt: #{$light-gray};
-  // --border-color: #{$border-color};
+  --bg-color: #{$background-color};
+  --background-color-alt: #{$light-gray};
+  --border-color: #{$border-color};
   --link-color: #{$link-color};
   --link-hover-color: #{$link-hover-color};
+  --text-muted: #{$dark-gray};
+  
+  /* Overlay colors */
+  --overlay-bg: rgba(0, 0, 0, 0.8); /* Semi-transparent black for light mode */
   
   /* Taxonomy filter specific vars */
   --tag-bg: #f0f0f0;
@@ -52,11 +56,15 @@ html.dark-mode {
   --secondary-color: #{lighten($secondary-color, 15%)};
   // --accent-color: #{lighten($accent-color, 15%)};
   --text-color: #{$dark-text-color};
-  // --background-color: #{$dark-background};
-  // --background-color-alt: #{$dark-surface};
-  // --border-color: #{$dark-border-color};
+  --bg-color: #{$dark-background};
+  --background-color-alt: #{$dark-surface};
+  --border-color: #{$dark-border-color};
   --link-color: #{lighten($link-color, 15%)};
   --link-hover-color: #{lighten($link-hover-color, 15%)};
+  --text-muted: #{$dark-gray-light};
+  
+  /* Overlay colors */
+  --overlay-bg: rgba(0, 0, 0, 0.9); /* Slightly darker for dark mode */
   
   /* Category filter specific dark mode vars */
   --tag-bg: #{rgba($dark-surface, 0.6)};

--- a/_sass/components/_search.scss
+++ b/_sass/components/_search.scss
@@ -39,7 +39,7 @@
   left: 0;
   width: 100%;
   height: 100vh; /* Use viewport height units */
-  background-color: rgba(0, 0, 0, 0.9); /* Changed from 0.85 to 0.9 for 90% opacity */
+  background-color: var(--overlay-bg, rgba(0, 0, 0, 0.8)); /* Using CSS variable with fallback */
   display: flex;
   align-items: center; /* Center vertically */
   justify-content: center; /* Center horizontally */
@@ -63,6 +63,7 @@
     min-height: 200px; /* Set minimum height to reduce layout shifts */
     height: auto;
     background-color: var(--bg-color);
+    color: var(--text-color); /* Explicitly set text color */
     border-radius: 8px;
     box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
     margin: 0; /* Remove any margin that might affect centering */
@@ -81,11 +82,12 @@
     align-items: center;
     justify-content: space-between;
     padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color, #edf2f7);
     
     h2 {
       margin: 0;
       font-size: 1.5rem;
+      color: var(--text-color, #2c3e50); /* Explicit text color */
     }
     
     .close-search {
@@ -119,10 +121,10 @@
       width: 100%;
       padding: 0.75rem 1rem;
       font-size: 1.1rem;
-      border: 1px solid var(--border-color);
+      border: 1px solid var(--border-color, #edf2f7);
       border-radius: 4px;
-      background-color: var(--bg-color);
-      color: var(--text-color);
+      background-color: var(--bg-color, #ffffff);
+      color: var(--text-color, #2c3e50);
       margin-bottom: 1.5rem;
       
       &:focus {
@@ -136,11 +138,11 @@
       margin-top: 1.5rem;
       text-align: center;
       padding-top: 1rem;
-      border-top: 1px solid var(--border-color);
+      border-top: 1px solid var(--border-color, #edf2f7);
       
       a {
         display: inline-block;
-        color: var(--primary-color);
+        color: var(--primary-color, #3273dc);
         font-size: 0.9rem;
         text-decoration: none;
         transition: color 0.2s ease;
@@ -223,14 +225,14 @@
 .search-results-container {
   .search-message {
     padding: 1rem;
-    color: var(--text-muted);
+    color: var(--text-muted, #8c9bab);
     text-align: center;
     font-style: italic;
   }
   
   .search-result {
     margin-bottom: 1.5rem;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color, #edf2f7);
     padding-bottom: 1.5rem;
     
     &:last-child {
@@ -239,12 +241,12 @@
     
     .search-result-link {
       display: block;
-      color: var(--text-color);
+      color: var(--text-color, #2c3e50);
       text-decoration: none;
       
       &:hover {
         .search-result-title {
-          color: var(--primary-color);
+          color: var(--primary-color, #3273dc);
         }
       }
     }


### PR DESCRIPTION
## Description
This pull request refines the CSS styles by introducing new variables for better maintainability and adding fallback values to ensure consistent rendering across different environments. The changes primarily focus on improving the base theme variables and enhancing the search component's styling.

### Base Theme Updates:
* Introduced new CSS variables such as `--bg-color`, `--text-muted`, and `--overlay-bg` for better clarity and organization of theme colors. Removed commented-out lines for unused variables.
* Updated dark mode variables to align with the new naming convention and added `--overlay-bg` for dark mode with a slightly darker background.

### Search Component Enhancements:
* Replaced hardcoded `rgba` values with the `--overlay-bg` variable and added fallback values for better compatibility.
* Explicitly set `--text-color` for search modal content, ensuring consistent text color rendering.
* Added fallback values for `--border-color`, `--text-color`, and `--primary-color` to maintain styling integrity in environments where variables may not be supported. [[1]](diffhunk://#diff-a445e4b99b42e19a792407bf82e3f678d137675b98b7bc082caf0d13f174b66dL84-R90) [[2]](diffhunk://#diff-a445e4b99b42e19a792407bf82e3f678d137675b98b7bc082caf0d13f174b66dL122-R127) [[3]](diffhunk://#diff-a445e4b99b42e19a792407bf82e3f678d137675b98b7bc082caf0d13f174b66dL139-R145) [[4]](diffhunk://#diff-a445e4b99b42e19a792407bf82e3f678d137675b98b7bc082caf0d13f174b66dL226-R235) [[5]](diffhunk://#diff-a445e4b99b42e19a792407bf82e3f678d137675b98b7bc082caf0d13f174b66dL242-R249)
## Related Issue
<!-- Reference any related issues using the format: Fixes #issue_number -->

## Type of Change
<!-- Mark the appropriate options with 'x' (e.g. [x]) -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI change
- [ ] ♻️ Code refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## Checklist
<!-- Mark the appropriate options with 'x' (e.g. [x]) -->

- [x] I have tested my changes
- [x] I have updated the documentation accordingly
- [x] My changes don't break existing functionality

## Screenshots
<!-- If applicable, add screenshots to demonstrate visual changes -->
